### PR TITLE
Add alr build check

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -1,0 +1,44 @@
+name: Ada Build Check
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up cache for Alire dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.config/alire
+          key: ${{ runner.os }}-alire-${{ hashFiles('**/alire.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-alire-
+
+      - name: Download Alire Linux Binary
+        run: |
+          curl -L -o alr.zip https://github.com/alire-project/alire/releases/download/v2.0.2/alr-2.0.2-bin-x86_64-linux.zip
+          unzip alr.zip -d alire
+          sudo mv alire/bin/alr /usr/local/bin/alr
+
+      - name: Set Non-Interactive Environment
+        run: |
+          export ALR_NONINTERACTIVE=1
+          export ALR_TOOLCHAIN_AUTO=1  # toolchain is automatically selected
+
+      - name: Install Project Dependencies
+        run: |
+          yes | alr with
+
+      - name: Build Project
+        run: |
+          yes | alr build

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -14,31 +14,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up cache for Alire dependencies
-        uses: actions/cache@v2
+      - name: Set up Alire
+        uses: alire-project/setup-alire@v3
         with:
-          path: ~/.config/alire
-          key: ${{ runner.os }}-alire-${{ hashFiles('**/alire.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-alire-
-
-      - name: Download Alire Linux Binary
-        run: |
-          curl -L -o alr.zip https://github.com/alire-project/alire/releases/download/v2.0.2/alr-2.0.2-bin-x86_64-linux.zip
-          unzip alr.zip -d alire
-          sudo mv alire/bin/alr /usr/local/bin/alr
-
-      - name: Set Non-Interactive Environment
-        run: |
-          export ALR_NONINTERACTIVE=1
-          export ALR_TOOLCHAIN_AUTO=1  # toolchain is automatically selected
+          version: "2.0.0"
+          toolchain: "gnat_native gprbuild"
+          msys2: false
+          cache: true                      
 
       - name: Install Project Dependencies
-        run: |
-          yes | alr with
+        run: alr with
 
       - name: Build Project
-        run: |
-          yes | alr build
+        run: alr build


### PR DESCRIPTION
This GitHub Actions workflow automates an Ada build check for a project using Alire. It triggers on pushes and pull requests to the master branch and performs check out code, set up cache, download alire, set non-interactive env. , install dependencies, and build project.